### PR TITLE
ci: add github basic workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    with:
-      config-repo: opportify/.github
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      config-repo: opportify/.github
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,4 +8,7 @@ on:
 jobs:
   release-drafter:
     uses: opportify/.github/.github/workflows/release-drafter.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release-drafter:
-    uses: opportify/.github/workflows/release-drafter.yml@main
+    uses: opportify/.github/.github/workflows/release-drafter.yml@main
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-drafter:
+    uses: opportify/.github/workflows/release-drafter.yml@main
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,10 @@
+name: Labeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  labeler:
+    uses: opportify/.github/workflows/labeler.yml@main
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,4 +7,7 @@ on:
 jobs:
   labeler:
     uses: opportify/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   labeler:
-    uses: opportify/.github/workflows/labeler.yml@main
+    uses: opportify/.github/.github/workflows/labeler.yml@main
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    with:
+      config-repo: opportify/.github
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    with:
-      config-repo: opportify/.github
     secrets: inherit


### PR DESCRIPTION
## What does this PR do?
Add release drafter and labeller as GitHub workflow.

## Why is this needed?
To leverage the centralized workflow from the org.
