### PR TITLE
fix: exception handler intervention

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Requires PHP v[7.4 or later](https://www.php.net/releases). It is also compatibl
 
 First, install Opportify via the Composer package manager:
 
-```
+```shell
 composer require opportify/opportify-sdk-php
 ```
 
 ### Calling Email Insights
 
-```
+```php
 use Opportify\Sdk\EmailInsights;
 
 $emailInsights = new EmailInsights("YOUR-API-KEY-HERE");
@@ -43,7 +43,7 @@ $result = $emailInsights->analyze($params);
 
 ### Calling IP Insights
 
-```
+```php
 use Opportify\Sdk\IpInsights;
 
 $ipInsights = new IpInsights("<YOUR-KEY-HERE>");
@@ -58,9 +58,32 @@ $result = $ipInsights->analyze($params);
 
 ### Enable Debug Mode
 
-```
+```php
 $clientInsights->setDebugMode(true);
 ```
+
+### Handling Error
+
+We strongly recommend that any usage of this SDK happens within a try-catch to properly handle any exceptions or errors.
+
+```php
+use OpenAPI\Client\ApiException;
+
+try {
+    
+    // Email or IP Insights usage...
+
+} catch (ApiException $e) {
+    throw new \Exception($e->getResponseBody());
+}
+```
+Below are the `ApiException` functions available:
+
+| Function | Type | Description |
+|----------|------|-------------|
+| `$e->getMessage();` | string | `"[403] Client error: POST https://api.opportify.ai/insights/v1/email/analyze resulted in a 403 Forbidden"` |
+| `$e->getResponseBody();` | string | `"{"errorMessage":"Your plan does not support AI features, please upgrade your plan or set enableAI as false.","errorCode":"INVALID_PLAN"}"` |
+| `$e->getCode();` | integer | `403` |
 
 ## About this package
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://api.opportify.ai/insights/v1/<service>/<endpoint>
 
 ## Requirements
 
-Requires PHP v[7.4 or later](https://www.php.net/releases). It is also compatible with v8.0.
+Requires PHP [v7.4 or later](https://www.php.net/releases). It is also compatible with v8.0.
 
 ## Getting Started
 
@@ -56,7 +56,7 @@ $params = [
 $result = $ipInsights->analyze($params);
 ```
 
-### Enable Debug Mode
+### Enabling Debug Mode
 
 ```php
 $clientInsights->setDebugMode(true);
@@ -79,9 +79,9 @@ try {
 ```
 Below are the `ApiException` functions available:
 
-| Function | Type | Description |
-|----------|------|-------------|
-| `$e->getMessage();` | string | `"[403] Client error: POST https://api.opportify.ai/insights/v1/email/analyze resulted in a 403 Forbidden"` |
+| Function | Type | Value Sample |
+|------------|------|--------------|
+| `$e->getMessage();` | string | `"[403] Client error: POST https://api.opportify.ai/insights/v1/... resulted in a 403 Forbidden"` |
 | `$e->getResponseBody();` | string | `"{"errorMessage":"Your plan does not support AI features, please upgrade your plan or set enableAI as false.","errorCode":"INVALID_PLAN"}"` |
 | `$e->getCode();` | integer | `403` |
 

--- a/src/EmailInsights.php
+++ b/src/EmailInsights.php
@@ -3,7 +3,6 @@
 namespace Opportify\Sdk;
 
 use OpenAPI\Client\Configuration as ApiConfiguration;
-use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Api\EmailInsightsApi;
 use OpenAPI\Client\Model\AnalyzeEmailRequest;
 use GuzzleHttp\Client;
@@ -47,12 +46,9 @@ class EmailInsights
 
         $analyzeEmailRequest = new AnalyzeEmailRequest($params); 
 
-        try {
-            $result = $this->apiInstance->analyzeEmail($analyzeEmailRequest);
-            return $result->jsonSerialize();
-        } catch (ApiException $e) {
-            throw new \Exception($e->getMessage());
-        }
+        $result = $this->apiInstance->analyzeEmail($analyzeEmailRequest);
+        return $result->jsonSerialize();
+       
     }
 
     /**

--- a/src/IpInsights.php
+++ b/src/IpInsights.php
@@ -3,7 +3,6 @@
 namespace Opportify\Sdk;
 
 use OpenAPI\Client\Configuration as ApiConfiguration;
-use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Api\IpInsightsApi;
 use OpenAPI\Client\Model\AnalyzeIpRequest;
 use GuzzleHttp\Client;
@@ -50,12 +49,9 @@ class IpInsights
 
         $analyzeIpRequest = new AnalyzeIpRequest($params);
 
-        try {
-            $result = $this->apiInstance->analyzeIp($analyzeIpRequest);
-            return $result->jsonSerialize();
-        } catch (ApiException $e) {
-            throw new \Exception($e->getMessage());
-        }
+        $result = $this->apiInstance->analyzeIp($analyzeIpRequest);
+        return $result->jsonSerialize();
+     
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?
Remove the exception handling from the wrapper.

## Why is this needed?
This is to let the core `ApiException` be thrown when an error occurs. 

## How did you implement it?
- Removed try-catch from the wrapper.

## Are there any breaking changes?
No.