### PR TITLE
docs: fix readme badge for unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Tests](https://img.shields.io/github/actions/workflow/status/opportify/opportify-sdk-php/tests.yml?label=tests&style=for-the-badge&labelColor=115e5c)](https://github.com/opportify/opportify-sdk-php/actions/workflows/tests.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/opportify/opportify-sdk-php/phpunit.yml?label=tests&style=for-the-badge&labelColor=115e5c)](https://github.com/opportify/opportify-sdk-php/actions/workflows/phpunit.yml)
 [![Packagist Downloads](https://img.shields.io/packagist/dt/opportify/opportify-sdk-php?style=for-the-badge&labelColor=115e5c)](https://packagist.org/packages/opportify/opportify-sdk-php)
 [![Packagist Version](https://img.shields.io/packagist/v/opportify/opportify-sdk-php?style=for-the-badge&labelColor=115e5c)](https://packagist.org/packages/opportify/opportify-sdk-php)
 [![License](https://img.shields.io/github/license/opportify/opportify-sdk-php?color=9cf&style=for-the-badge&labelColor=115e5c)](https://github.com/opportify/opportify-sdk-php/blob/main/LICENSE)


### PR DESCRIPTION
## What does this PR do?
This pull request includes a small change to the `README.md` file. 

## Why is this needed?
The change updates the URL for the tests badge to point to the correct GitHub Actions workflow file.

## How did you implement it?
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the URL for the tests badge to reference `phpunit.yml` instead of `tests.yml`.

## Are there any breaking changes?
No.

## Testing Steps:
1. View the updated on [README](https://github.com/opportify/opportify-sdk-php/tree/docs/add-badges-to-readme-file)