### PR TITLE
fix: ip insights api class naming

### DIFF
--- a/src/IpInsights.php
+++ b/src/IpInsights.php
@@ -3,7 +3,7 @@
 namespace Opportify\Sdk;
 
 use GuzzleHttp\Client;
-use OpenAPI\Client\Api\IpInsightsApi;
+use OpenAPI\Client\Api\IPInsightsApi as IpInsightsApi;
 use OpenAPI\Client\Configuration as ApiConfiguration;
 use OpenAPI\Client\Model\AnalyzeIpRequest;
 


### PR DESCRIPTION
## What does this PR do?
Update the class reference naming in `Ipinsights.php`.

## Why is this needed?
In some PHP environments, the exact naming match is required and may throw an error.

`ERROR: Class "OpenAPI\Client\Api\IpInsightsApi" not found {"exception":"[object] (Error(code: 0): Class \"OpenAPI\\Client\\Api\\IpInsightsApi\" not found `

## How did you implement it?
- Updated the class naming.

## Are there any breaking changes?
No.



