### PR TITLE
ci: adjust accepted packagist responses

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -20,7 +20,7 @@ jobs:
           RESPONSE=$(curl -s -w "%{http_code}" -o /dev/null -X POST "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_API_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{\"repository\": \"${PACKAGE_NAME}\"}")
-          if [ "$RESPONSE" != "200" ]; then
+            if [ "$RESPONSE" != "200" ] && [ "$RESPONSE" != "202" ]; then
             echo "Packagist update failed with status code: $RESPONSE"
             exit 1
           fi


### PR DESCRIPTION
## What does this PR do?
Update the Packagist update workflow.

## Why is this needed?
This is to accept both responses `200` and `202` as success. Also, the variable value PACKAGE_NAME was adjusted since the value passed was incorrect.

## How did you implement it?
- Added 202 as an additional response code

## Are there any breaking changes?
No.

