### PR TITLE
hotfix: final url api issue

### DIFF
--- a/src/EmailInsights.php
+++ b/src/EmailInsights.php
@@ -70,7 +70,20 @@ class EmailInsights
      */
     private function updateFinalUrl(): void
     {
-        $this->finalUrl = "{$this->host}/{$this->prefix}/{$this->version}";
+        $base = rtrim($this->host, '/');
+        $segments = [];
+
+        $prefix = trim($this->prefix, '/');
+        if ($prefix !== '') {
+            $segments[] = $prefix;
+        }
+
+        $version = trim($this->version, '/');
+        if ($version !== '') {
+            $segments[] = $version;
+        }
+
+        $this->finalUrl = $base.(count($segments) ? '/'.implode('/', $segments) : '');
     }
 
     /**

--- a/src/IpInsights.php
+++ b/src/IpInsights.php
@@ -71,7 +71,20 @@ class IpInsights
      */
     private function updateFinalUrl(): void
     {
-        $this->finalUrl = "{$this->host}/{$this->prefix}/{$this->version}";
+        $base = rtrim($this->host, '/');
+        $segments = [];
+
+        $prefix = trim($this->prefix, '/');
+        if ($prefix !== '') {
+            $segments[] = $prefix;
+        }
+
+        $version = trim($this->version, '/');
+        if ($version !== '') {
+            $segments[] = $version;
+        }
+
+        $this->finalUrl = $base.(count($segments) ? '/'.implode('/', $segments) : '');
     }
 
     /**

--- a/tests/EmailInsightsTest.php
+++ b/tests/EmailInsightsTest.php
@@ -358,4 +358,53 @@ class EmailInsightsTest extends TestCase
         $this->assertEquals('COMPLETED', $response->status);
         $this->assertEquals(100, $response->progress);
     }
+
+    public function urlScenariosProvider(): array
+    {
+        return [
+            'all segments' => [
+                'https://api.opportify.ai', 'insights', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'empty prefix' => [
+                'https://api.opportify.ai', '', 'v1', 'https://api.opportify.ai/v1',
+            ],
+            'empty version' => [
+                'https://api.opportify.ai', 'insights', '', 'https://api.opportify.ai/insights',
+            ],
+            'empty both' => [
+                'https://api.opportify.ai', '', '', 'https://api.opportify.ai',
+            ],
+            'host with trailing slash, others normal' => [
+                'https://api.opportify.ai/', 'insights', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'prefix with slashes' => [
+                'https://api.opportify.ai', '/insights/', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'version with slashes' => [
+                'https://api.opportify.ai', 'insights', '/v2/', 'https://api.opportify.ai/insights/v2',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider urlScenariosProvider
+     */
+    public function test_final_url_building($host, $prefix, $version, $expected)
+    {
+        $emailInsights = new EmailInsights('fake_api_key');
+
+        $emailInsights->setHost($host);
+        $emailInsights->setPrefix($prefix);
+        $emailInsights->setVersion($version);
+
+        // Force refresh to rebuild apiInstance & finalUrl
+        $reflection = new \ReflectionClass($emailInsights);
+        $method = $reflection->getMethod('refreshApiInstance');
+        $method->setAccessible(true);
+        $method->invokeArgs($emailInsights, []);
+
+        $property = $reflection->getProperty('finalUrl');
+        $property->setAccessible(true);
+        $this->assertEquals($expected, $property->getValue($emailInsights));
+    }
 }

--- a/tests/IpInsightsTest.php
+++ b/tests/IpInsightsTest.php
@@ -372,4 +372,52 @@ class IpInsightsTest extends TestCase
         $this->assertEquals('COMPLETED', $response->status);
         $this->assertEquals(100, $response->progress);
     }
+
+    public function urlScenariosProvider(): array
+    {
+        return [
+            'all segments' => [
+                'https://api.opportify.ai', 'insights', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'empty prefix' => [
+                'https://api.opportify.ai', '', 'v1', 'https://api.opportify.ai/v1',
+            ],
+            'empty version' => [
+                'https://api.opportify.ai', 'insights', '', 'https://api.opportify.ai/insights',
+            ],
+            'empty both' => [
+                'https://api.opportify.ai', '', '', 'https://api.opportify.ai',
+            ],
+            'host with trailing slash, others normal' => [
+                'https://api.opportify.ai/', 'insights', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'prefix with slashes' => [
+                'https://api.opportify.ai', '/insights/', 'v1', 'https://api.opportify.ai/insights/v1',
+            ],
+            'version with slashes' => [
+                'https://api.opportify.ai', 'insights', '/v2/', 'https://api.opportify.ai/insights/v2',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider urlScenariosProvider
+     */
+    public function test_final_url_building($host, $prefix, $version, $expected)
+    {
+        $insights = new IpInsights('fake_api_key');
+
+        $insights->setHost($host);
+        $insights->setPrefix($prefix);
+        $insights->setVersion($version);
+
+        $reflection = new \ReflectionClass($insights);
+        $method = $reflection->getMethod('refreshApiInstance');
+        $method->setAccessible(true);
+        $method->invokeArgs($insights, []);
+
+        $property = $reflection->getProperty('finalUrl');
+        $property->setAccessible(true);
+        $this->assertEquals($expected, $property->getValue($insights));
+    }
 }


### PR DESCRIPTION
## Overview
This pull request improves the way API endpoint URLs are constructed in both the `EmailInsights` and `IpInsights` classes, ensuring that segments are properly trimmed and concatenated regardless of empty values or extra slashes. It also adds comprehensive tests to verify the URL building logic under various scenarios.

### URL construction logic improvements

* Updated the `updateFinalUrl` method in both `EmailInsights` and `IpInsights` to trim slashes from `host`, `prefix`, and `version`, and to only include non-empty segments when building the final URL. This prevents issues with double slashes or missing segments. [[1]](diffhunk://#diff-4ce86efd33e64f7df143a3e1c11323a959f25a1ac4d100f2e3851aee4e6b17d0L73-R86) [[2]](diffhunk://#diff-b6ed2299bbb0e6f2d0cc0702d8dff52a3a954256ef9800ae6ec8c74eaeaf9dd7L74-R87)

### Test coverage enhancements

* Added `urlScenariosProvider` data providers and new tests in `EmailInsightsTest.php` and `IpInsightsTest.php` to verify correct URL construction for various combinations of host, prefix, and version values, including cases with empty segments and extra slashes. [[1]](diffhunk://#diff-c57a3d53ba167983369256910601bae6fd3f71e52d29ab448d27984554243a22R361-R409) [[2]](diffhunk://#diff-91f9a5c08c2c179a0caa1a1bdbc30118ca587aba073e2707f20622dfe6594902R375-R422)