### PR TITLE
chore: sync PHP SDK with latest API spec changes

### DIFF
--- a/lib/fraud-intel/.openapi-generator/FILES
+++ b/lib/fraud-intel/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .php-cs-fixer.dist.php
 .travis.yml
 README.md
@@ -9,11 +8,9 @@ docs/Model/AbuseContact.md
 docs/Model/AddressSignals.md
 docs/Model/AdminContact.md
 docs/Model/AnalyzeFraud200Response.md
-docs/Model/AnalyzeFraud200ResponseMeta.md
 docs/Model/AnalyzeFraud200ResponseSources.md
 docs/Model/AnalyzeFraud200ResponseSourcesContent.md
 docs/Model/AnalyzeFraud200ResponseSourcesEmail.md
-docs/Model/AnalyzeFraud200ResponseSourcesEmailFormat.md
 docs/Model/AnalyzeFraud200ResponseSourcesGeo.md
 docs/Model/AnalyzeFraud200ResponseSourcesGeoSignals.md
 docs/Model/AnalyzeFraud200ResponseSourcesIp.md
@@ -55,11 +52,9 @@ lib/Model/AbuseContact.php
 lib/Model/AddressSignals.php
 lib/Model/AdminContact.php
 lib/Model/AnalyzeFraud200Response.php
-lib/Model/AnalyzeFraud200ResponseMeta.php
 lib/Model/AnalyzeFraud200ResponseSources.php
 lib/Model/AnalyzeFraud200ResponseSourcesContent.php
 lib/Model/AnalyzeFraud200ResponseSourcesEmail.php
-lib/Model/AnalyzeFraud200ResponseSourcesEmailFormat.php
 lib/Model/AnalyzeFraud200ResponseSourcesGeo.php
 lib/Model/AnalyzeFraud200ResponseSourcesGeoSignals.php
 lib/Model/AnalyzeFraud200ResponseSourcesIp.php
@@ -98,9 +93,7 @@ test/Api/FraudProtectionApiTest.php
 test/Model/AbuseContactTest.php
 test/Model/AddressSignalsTest.php
 test/Model/AdminContactTest.php
-test/Model/AnalyzeFraud200ResponseMetaTest.php
 test/Model/AnalyzeFraud200ResponseSourcesContentTest.php
-test/Model/AnalyzeFraud200ResponseSourcesEmailFormatTest.php
 test/Model/AnalyzeFraud200ResponseSourcesEmailTest.php
 test/Model/AnalyzeFraud200ResponseSourcesGeoSignalsTest.php
 test/Model/AnalyzeFraud200ResponseSourcesGeoTest.php

--- a/lib/fraud-intel/.php-cs-fixer.dist.php
+++ b/lib/fraud-intel/.php-cs-fixer.dist.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @generated
+ * @link https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/HEAD/doc/config.rst
+ */
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor')
+    ->exclude('test')
+    ->exclude('tests')
+;
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+        '@PSR12' => true,
+        'phpdoc_order' => true,
+        'array_syntax' => [ 'syntax' => 'short' ],
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'no_trailing_whitespace' => false,
+        'no_trailing_whitespace_in_comment' => false,
+        'braces' => false,
+        'single_blank_line_at_eof' => false,
+        'blank_line_after_namespace' => false,
+        'no_leading_import_slash' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/lib/fraud-intel/lib/Api/FraudProtectionApi.php
+++ b/lib/fraud-intel/lib/Api/FraudProtectionApi.php
@@ -93,7 +93,7 @@ class FraudProtectionApi
     /**
      * Operation analyzeFraud
      *
-     * Analyze Fraud
+     * Analyze
      *
      * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraudRequest  $analyze_fraud_request  analyze_fraud_request (required)
      * @param  string  $contentType  The value for the Content-Type header. Check self::contentTypes['analyzeFraud'] to see the possible values for this operation
@@ -112,7 +112,7 @@ class FraudProtectionApi
     /**
      * Operation analyzeFraudWithHttpInfo
      *
-     * Analyze Fraud
+     * Analyze
      *
      * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraudRequest  $analyze_fraud_request  (required)
      * @param  string  $contentType  The value for the Content-Type header. Check self::contentTypes['analyzeFraud'] to see the possible values for this operation
@@ -291,7 +291,7 @@ class FraudProtectionApi
     /**
      * Operation analyzeFraudAsync
      *
-     * Analyze Fraud
+     * Analyze
      *
      * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraudRequest  $analyze_fraud_request  (required)
      * @param  string  $contentType  The value for the Content-Type header. Check self::contentTypes['analyzeFraud'] to see the possible values for this operation
@@ -312,7 +312,7 @@ class FraudProtectionApi
     /**
      * Operation analyzeFraudAsyncWithHttpInfo
      *
-     * Analyze Fraud
+     * Analyze
      *
      * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraudRequest  $analyze_fraud_request  (required)
      * @param  string  $contentType  The value for the Content-Type header. Check self::contentTypes['analyzeFraud'] to see the possible values for this operation
@@ -465,7 +465,7 @@ class FraudProtectionApi
         $options = [];
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-            if (!$options[RequestOptions::DEBUG]) {
+            if (! $options[RequestOptions::DEBUG]) {
                 throw new \RuntimeException('Failed to open the debug file: '.$this->config->getDebugFile());
             }
         }

--- a/lib/fraud-intel/lib/Configuration.php
+++ b/lib/fraud-intel/lib/Configuration.php
@@ -289,7 +289,7 @@ class Configuration
      */
     public function setUserAgent($userAgent)
     {
-        if (!is_string($userAgent)) {
+        if (! is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
         }
 
@@ -526,7 +526,7 @@ class Configuration
         // go through variable and assign a value
         foreach ($host['variables'] ?? [] as $name => $variable) {
             if (array_key_exists($name, $variables)) { // check to see if it's in the variables provided by the user
-                if (!isset($variable['enum_values']) || in_array($variables[$name], $variable['enum_values'], true)) { // check to see if the value is in the enum
+                if (! isset($variable['enum_values']) || in_array($variables[$name], $variable['enum_values'], true)) { // check to see if the value is in the enum
                     $url = str_replace('{'.$name.'}', $variables[$name], $url);
                 } else {
                     throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].'. Must be '.implode(',', $variable['enum_values']).'.');

--- a/lib/fraud-intel/lib/FormDataProcessor.php
+++ b/lib/fraud-intel/lib/FormDataProcessor.php
@@ -81,7 +81,7 @@ class FormDataProcessor
         foreach ($source as $key => $val) {
             $currentName .= $currentPrefix.$key;
 
-            if (is_array($val) && !empty($val)) {
+            if (is_array($val) && ! empty($val)) {
                 $currentName .= $currentSuffix;
                 $result += self::flatten($val, $currentName);
             } else {
@@ -123,7 +123,7 @@ class FormDataProcessor
             return $this->processModel($value);
         }
 
-        if (is_array($value) || (is_object($value) && !$value instanceof \DateTimeInterface)) {
+        if (is_array($value) || (is_object($value) && ! $value instanceof \DateTimeInterface)) {
             $data = [];
 
             foreach ($value as $k => $v) {

--- a/lib/fraud-intel/lib/HeaderSelector.php
+++ b/lib/fraud-intel/lib/HeaderSelector.php
@@ -19,7 +19,7 @@ class HeaderSelector
             $headers['Accept'] = $accept;
         }
 
-        if (!$isMultipart) {
+        if (! $isMultipart) {
             if ($contentType === '') {
                 $contentType = 'application/json';
             }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200Response.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200Response.php
@@ -28,7 +28,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => 'string',
         'factors' => 'string[]',
         'sources' => '\OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSources',
-        'meta' => '\OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseMeta',
     ];
 
     /**
@@ -45,7 +44,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => null,
         'factors' => null,
         'sources' => null,
-        'meta' => null,
     ];
 
     /**
@@ -58,7 +56,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => false,
         'factors' => false,
         'sources' => false,
-        'meta' => false,
     ];
 
     /**
@@ -143,7 +140,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => 'level',
         'factors' => 'factors',
         'sources' => 'sources',
-        'meta' => 'meta',
     ];
 
     /**
@@ -156,7 +152,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => 'setLevel',
         'factors' => 'setFactors',
         'sources' => 'setSources',
-        'meta' => 'setMeta',
     ];
 
     /**
@@ -169,7 +164,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         'level' => 'getLevel',
         'factors' => 'getFactors',
         'sources' => 'getSources',
-        'meta' => 'getMeta',
     ];
 
     /**
@@ -232,7 +226,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
         $this->setIfExists('level', $data ?? [], null);
         $this->setIfExists('factors', $data ?? [], null);
         $this->setIfExists('sources', $data ?? [], null);
-        $this->setIfExists('meta', $data ?? [], null);
     }
 
     /**
@@ -260,11 +253,17 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     {
         $invalidProperties = [];
 
+        if ($this->container['score'] === null) {
+            $invalidProperties[] = "'score' can't be null";
+        }
+        if ($this->container['level'] === null) {
+            $invalidProperties[] = "'level' can't be null";
+        }
+        if ($this->container['factors'] === null) {
+            $invalidProperties[] = "'factors' can't be null";
+        }
         if ($this->container['sources'] === null) {
             $invalidProperties[] = "'sources' can't be null";
-        }
-        if ($this->container['meta'] === null) {
-            $invalidProperties[] = "'meta' can't be null";
         }
 
         return $invalidProperties;
@@ -284,7 +283,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Gets score
      *
-     * @return int|null
+     * @return int
      */
     public function getScore()
     {
@@ -294,7 +293,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Sets score
      *
-     * @param  int|null  $score  Composite fraud risk score normalized to 200–1000. Present when `enableAI` is `true`.
+     * @param  int  $score  Composite fraud risk score normalized to 200–1000. Always present in the response.
      * @return self
      */
     public function setScore($score)
@@ -310,7 +309,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Gets level
      *
-     * @return string|null
+     * @return string
      */
     public function getLevel()
     {
@@ -320,7 +319,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Sets level
      *
-     * @param  string|null  $level  Human-readable risk level derived from `score`. Present when `enableAI` is `true`. Allowed values: lowest, low, medium, high, highest.
+     * @param  string  $level  Human-readable risk level derived from `score`. Always present in the response. Allowed values: lowest, low, medium, high, highest.
      * @return self
      */
     public function setLevel($level)
@@ -336,7 +335,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Gets factors
      *
-     * @return string[]|null
+     * @return string[]
      */
     public function getFactors()
     {
@@ -346,7 +345,7 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
     /**
      * Sets factors
      *
-     * @param  string[]|null  $factors  Top weighted risk factor codes contributing to the composite score. Present when `enableAI` is `true`.
+     * @param  string[]  $factors  Top weighted risk factor codes contributing to the composite score. Always present in the response. Each code is prefixed with its source using the format `source:factor-code`. Possible source…
      * @return self
      */
     public function setFactors($factors)
@@ -381,32 +380,6 @@ class AnalyzeFraud200Response implements \JsonSerializable, ArrayAccess, ModelIn
             throw new \InvalidArgumentException('non-nullable sources cannot be null');
         }
         $this->container['sources'] = $sources;
-
-        return $this;
-    }
-
-    /**
-     * Gets meta
-     *
-     * @return \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseMeta
-     */
-    public function getMeta()
-    {
-        return $this->container['meta'];
-    }
-
-    /**
-     * Sets meta
-     *
-     * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseMeta  $meta  meta
-     * @return self
-     */
-    public function setMeta($meta)
-    {
-        if (is_null($meta)) {
-            throw new \InvalidArgumentException('non-nullable meta cannot be null');
-        }
-        $this->container['meta'] = $meta;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSources.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSources.php
@@ -58,7 +58,7 @@ class AnalyzeFraud200ResponseSources implements \JsonSerializable, ArrayAccess, 
     protected static array $openAPINullables = [
         'email' => false,
         'ip' => false,
-        'content' => false,
+        'content' => true,
         'session' => true,
         'velocity' => true,
         'geo' => true,
@@ -352,7 +352,14 @@ class AnalyzeFraud200ResponseSources implements \JsonSerializable, ArrayAccess, 
     public function setContent($content)
     {
         if (is_null($content)) {
-            throw new \InvalidArgumentException('non-nullable content cannot be null');
+            array_push($this->openAPINullablesSetToNull, 'content');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('content', $nullablesSetToNull);
+            if ($index !== false) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
         }
         $this->container['content'] = $content;
 

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesContent.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesContent.php
@@ -358,7 +358,7 @@ class AnalyzeFraud200ResponseSourcesContent implements \JsonSerializable, ArrayA
     /**
      * Sets risk_report
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReport|null  $risk_report  AI risk report for content signals. Present when `enableAI` is `true`.
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReport|null  $risk_report  Risk report for content signals. Present when content fields were supplied.
      * @return self
      */
     public function setRiskReport($risk_report)

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesEmail.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesEmail.php
@@ -24,11 +24,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @var string[]
      */
     protected static $openAPITypes = [
-        'format' => '\OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesEmailFormat',
+        'email_address' => 'string',
+        'email_provider' => 'string',
+        'email_type' => 'string',
+        'is_deliverable' => 'string',
+        'is_catch_all' => 'bool',
+        'is_mailbox_full' => 'bool',
+        'is_reachable' => 'bool',
+        'is_format_valid' => 'bool',
+        'email_correction' => 'string',
+        'email_auto_corrected_from' => 'string',
         'address_signals' => '\OpenAPI\FraudIntel\Client\Model\AddressSignals',
-        'dns' => '\OpenAPI\FraudIntel\Client\Model\EmailDNS',
-        'domain' => '\OpenAPI\FraudIntel\Client\Model\EmailDomain',
+        'email_dns' => '\OpenAPI\FraudIntel\Client\Model\EmailDNS',
         'risk_report' => '\OpenAPI\FraudIntel\Client\Model\RiskReportEmail',
+        'domain' => '\OpenAPI\FraudIntel\Client\Model\EmailDomain',
     ];
 
     /**
@@ -41,11 +50,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @psalm-var array<string, string|null>
      */
     protected static $openAPIFormats = [
-        'format' => null,
+        'email_address' => null,
+        'email_provider' => null,
+        'email_type' => null,
+        'is_deliverable' => null,
+        'is_catch_all' => null,
+        'is_mailbox_full' => null,
+        'is_reachable' => null,
+        'is_format_valid' => null,
+        'email_correction' => null,
+        'email_auto_corrected_from' => null,
         'address_signals' => null,
-        'dns' => null,
-        'domain' => null,
+        'email_dns' => null,
         'risk_report' => null,
+        'domain' => null,
     ];
 
     /**
@@ -54,11 +72,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @var bool[]
      */
     protected static array $openAPINullables = [
-        'format' => false,
+        'email_address' => false,
+        'email_provider' => false,
+        'email_type' => false,
+        'is_deliverable' => false,
+        'is_catch_all' => false,
+        'is_mailbox_full' => false,
+        'is_reachable' => false,
+        'is_format_valid' => false,
+        'email_correction' => false,
+        'email_auto_corrected_from' => false,
         'address_signals' => false,
-        'dns' => false,
-        'domain' => false,
+        'email_dns' => false,
         'risk_report' => false,
+        'domain' => false,
     ];
 
     /**
@@ -139,11 +166,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @var string[]
      */
     protected static $attributeMap = [
-        'format' => 'format',
+        'email_address' => 'emailAddress',
+        'email_provider' => 'emailProvider',
+        'email_type' => 'emailType',
+        'is_deliverable' => 'isDeliverable',
+        'is_catch_all' => 'isCatchAll',
+        'is_mailbox_full' => 'isMailboxFull',
+        'is_reachable' => 'isReachable',
+        'is_format_valid' => 'isFormatValid',
+        'email_correction' => 'emailCorrection',
+        'email_auto_corrected_from' => 'emailAutoCorrectedFrom',
         'address_signals' => 'addressSignals',
-        'dns' => 'dns',
-        'domain' => 'domain',
+        'email_dns' => 'emailDNS',
         'risk_report' => 'riskReport',
+        'domain' => 'domain',
     ];
 
     /**
@@ -152,11 +188,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @var string[]
      */
     protected static $setters = [
-        'format' => 'setFormat',
+        'email_address' => 'setEmailAddress',
+        'email_provider' => 'setEmailProvider',
+        'email_type' => 'setEmailType',
+        'is_deliverable' => 'setIsDeliverable',
+        'is_catch_all' => 'setIsCatchAll',
+        'is_mailbox_full' => 'setIsMailboxFull',
+        'is_reachable' => 'setIsReachable',
+        'is_format_valid' => 'setIsFormatValid',
+        'email_correction' => 'setEmailCorrection',
+        'email_auto_corrected_from' => 'setEmailAutoCorrectedFrom',
         'address_signals' => 'setAddressSignals',
-        'dns' => 'setDns',
-        'domain' => 'setDomain',
+        'email_dns' => 'setEmailDns',
         'risk_report' => 'setRiskReport',
+        'domain' => 'setDomain',
     ];
 
     /**
@@ -165,11 +210,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      * @var string[]
      */
     protected static $getters = [
-        'format' => 'getFormat',
+        'email_address' => 'getEmailAddress',
+        'email_provider' => 'getEmailProvider',
+        'email_type' => 'getEmailType',
+        'is_deliverable' => 'getIsDeliverable',
+        'is_catch_all' => 'getIsCatchAll',
+        'is_mailbox_full' => 'getIsMailboxFull',
+        'is_reachable' => 'getIsReachable',
+        'is_format_valid' => 'getIsFormatValid',
+        'email_correction' => 'getEmailCorrection',
+        'email_auto_corrected_from' => 'getEmailAutoCorrectedFrom',
         'address_signals' => 'getAddressSignals',
-        'dns' => 'getDns',
-        'domain' => 'getDomain',
+        'email_dns' => 'getEmailDns',
         'risk_report' => 'getRiskReport',
+        'domain' => 'getDomain',
     ];
 
     /**
@@ -228,11 +282,20 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
      */
     public function __construct(?array $data = null)
     {
-        $this->setIfExists('format', $data ?? [], null);
+        $this->setIfExists('email_address', $data ?? [], null);
+        $this->setIfExists('email_provider', $data ?? [], null);
+        $this->setIfExists('email_type', $data ?? [], null);
+        $this->setIfExists('is_deliverable', $data ?? [], null);
+        $this->setIfExists('is_catch_all', $data ?? [], null);
+        $this->setIfExists('is_mailbox_full', $data ?? [], null);
+        $this->setIfExists('is_reachable', $data ?? [], null);
+        $this->setIfExists('is_format_valid', $data ?? [], null);
+        $this->setIfExists('email_correction', $data ?? [], null);
+        $this->setIfExists('email_auto_corrected_from', $data ?? [], null);
         $this->setIfExists('address_signals', $data ?? [], null);
-        $this->setIfExists('dns', $data ?? [], null);
-        $this->setIfExists('domain', $data ?? [], null);
+        $this->setIfExists('email_dns', $data ?? [], null);
         $this->setIfExists('risk_report', $data ?? [], null);
+        $this->setIfExists('domain', $data ?? [], null);
     }
 
     /**
@@ -260,6 +323,40 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     {
         $invalidProperties = [];
 
+        if ($this->container['email_address'] === null) {
+            $invalidProperties[] = "'email_address' can't be null";
+        }
+        if ($this->container['email_provider'] === null) {
+            $invalidProperties[] = "'email_provider' can't be null";
+        }
+        if ($this->container['email_type'] === null) {
+            $invalidProperties[] = "'email_type' can't be null";
+        }
+        if ($this->container['is_deliverable'] === null) {
+            $invalidProperties[] = "'is_deliverable' can't be null";
+        }
+        if ($this->container['is_catch_all'] === null) {
+            $invalidProperties[] = "'is_catch_all' can't be null";
+        }
+        if ($this->container['is_mailbox_full'] === null) {
+            $invalidProperties[] = "'is_mailbox_full' can't be null";
+        }
+        if ($this->container['is_reachable'] === null) {
+            $invalidProperties[] = "'is_reachable' can't be null";
+        }
+        if ($this->container['is_format_valid'] === null) {
+            $invalidProperties[] = "'is_format_valid' can't be null";
+        }
+        if ($this->container['email_correction'] === null) {
+            $invalidProperties[] = "'email_correction' can't be null";
+        }
+        if ($this->container['address_signals'] === null) {
+            $invalidProperties[] = "'address_signals' can't be null";
+        }
+        if ($this->container['email_dns'] === null) {
+            $invalidProperties[] = "'email_dns' can't be null";
+        }
+
         return $invalidProperties;
     }
 
@@ -275,27 +372,261 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     }
 
     /**
-     * Gets format
+     * Gets email_address
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesEmailFormat|null
+     * @return string
      */
-    public function getFormat()
+    public function getEmailAddress()
     {
-        return $this->container['format'];
+        return $this->container['email_address'];
     }
 
     /**
-     * Sets format
+     * Sets email_address
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesEmailFormat|null  $format  format
+     * @param  string  $email_address  Normalized email address returned by the service (always lower-case).
      * @return self
      */
-    public function setFormat($format)
+    public function setEmailAddress($email_address)
     {
-        if (is_null($format)) {
-            throw new \InvalidArgumentException('non-nullable format cannot be null');
+        if (is_null($email_address)) {
+            throw new \InvalidArgumentException('non-nullable email_address cannot be null');
         }
-        $this->container['format'] = $format;
+        $this->container['email_address'] = $email_address;
+
+        return $this;
+    }
+
+    /**
+     * Gets email_provider
+     *
+     * @return string
+     */
+    public function getEmailProvider()
+    {
+        return $this->container['email_provider'];
+    }
+
+    /**
+     * Sets email_provider
+     *
+     * @param  string  $email_provider  Provider slug derived from the domain, or `unknown` when not classified.
+     * @return self
+     */
+    public function setEmailProvider($email_provider)
+    {
+        if (is_null($email_provider)) {
+            throw new \InvalidArgumentException('non-nullable email_provider cannot be null');
+        }
+        $this->container['email_provider'] = $email_provider;
+
+        return $this;
+    }
+
+    /**
+     * Gets email_type
+     *
+     * @return string
+     */
+    public function getEmailType()
+    {
+        return $this->container['email_type'];
+    }
+
+    /**
+     * Sets email_type
+     *
+     * @param  string  $email_type  Email classification based on provider and enrichment signals. Allowed values: `private`, `free`, `disposable`, `unknown`.
+     * @return self
+     */
+    public function setEmailType($email_type)
+    {
+        if (is_null($email_type)) {
+            throw new \InvalidArgumentException('non-nullable email_type cannot be null');
+        }
+        $this->container['email_type'] = $email_type;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_deliverable
+     *
+     * @return string
+     */
+    public function getIsDeliverable()
+    {
+        return $this->container['is_deliverable'];
+    }
+
+    /**
+     * Sets is_deliverable
+     *
+     * @param  string  $is_deliverable  Checks if the email address exists and is deliverable using SMTP handshake simulation. Allowed values: `yes`, `no`, `unknown`.
+     * @return self
+     */
+    public function setIsDeliverable($is_deliverable)
+    {
+        if (is_null($is_deliverable)) {
+            throw new \InvalidArgumentException('non-nullable is_deliverable cannot be null');
+        }
+        $this->container['is_deliverable'] = $is_deliverable;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_catch_all
+     *
+     * @return bool
+     */
+    public function getIsCatchAll()
+    {
+        return $this->container['is_catch_all'];
+    }
+
+    /**
+     * Sets is_catch_all
+     *
+     * @param  bool  $is_catch_all  Determines if the email domain is configured as a catch-all.
+     * @return self
+     */
+    public function setIsCatchAll($is_catch_all)
+    {
+        if (is_null($is_catch_all)) {
+            throw new \InvalidArgumentException('non-nullable is_catch_all cannot be null');
+        }
+        $this->container['is_catch_all'] = $is_catch_all;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_mailbox_full
+     *
+     * @return bool
+     */
+    public function getIsMailboxFull()
+    {
+        return $this->container['is_mailbox_full'];
+    }
+
+    /**
+     * Sets is_mailbox_full
+     *
+     * @param  bool  $is_mailbox_full  Determines if the mailbox associated with the email is full.
+     * @return self
+     */
+    public function setIsMailboxFull($is_mailbox_full)
+    {
+        if (is_null($is_mailbox_full)) {
+            throw new \InvalidArgumentException('non-nullable is_mailbox_full cannot be null');
+        }
+        $this->container['is_mailbox_full'] = $is_mailbox_full;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_reachable
+     *
+     * @return bool
+     */
+    public function getIsReachable()
+    {
+        return $this->container['is_reachable'];
+    }
+
+    /**
+     * Sets is_reachable
+     *
+     * @param  bool  $is_reachable  Confirms if the email domain has valid MX DNS records using DNS lookup.
+     * @return self
+     */
+    public function setIsReachable($is_reachable)
+    {
+        if (is_null($is_reachable)) {
+            throw new \InvalidArgumentException('non-nullable is_reachable cannot be null');
+        }
+        $this->container['is_reachable'] = $is_reachable;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_format_valid
+     *
+     * @return bool
+     */
+    public function getIsFormatValid()
+    {
+        return $this->container['is_format_valid'];
+    }
+
+    /**
+     * Sets is_format_valid
+     *
+     * @param  bool  $is_format_valid  Indicates if the email address meets syntax validation rules.
+     * @return self
+     */
+    public function setIsFormatValid($is_format_valid)
+    {
+        if (is_null($is_format_valid)) {
+            throw new \InvalidArgumentException('non-nullable is_format_valid cannot be null');
+        }
+        $this->container['is_format_valid'] = $is_format_valid;
+
+        return $this;
+    }
+
+    /**
+     * Gets email_correction
+     *
+     * @return string
+     */
+    public function getEmailCorrection()
+    {
+        return $this->container['email_correction'];
+    }
+
+    /**
+     * Sets email_correction
+     *
+     * @param  string  $email_correction  The corrected email address when the system is highly confident about a typo or misspelling. Empty string when no correction is needed.
+     * @return self
+     */
+    public function setEmailCorrection($email_correction)
+    {
+        if (is_null($email_correction)) {
+            throw new \InvalidArgumentException('non-nullable email_correction cannot be null');
+        }
+        $this->container['email_correction'] = $email_correction;
+
+        return $this;
+    }
+
+    /**
+     * Gets email_auto_corrected_from
+     *
+     * @return string|null
+     */
+    public function getEmailAutoCorrectedFrom()
+    {
+        return $this->container['email_auto_corrected_from'];
+    }
+
+    /**
+     * Sets email_auto_corrected_from
+     *
+     * @param  string|null  $email_auto_corrected_from  The original email address before auto-correction was applied. Present only when auto-correction was applied.
+     * @return self
+     */
+    public function setEmailAutoCorrectedFrom($email_auto_corrected_from)
+    {
+        if (is_null($email_auto_corrected_from)) {
+            throw new \InvalidArgumentException('non-nullable email_auto_corrected_from cannot be null');
+        }
+        $this->container['email_auto_corrected_from'] = $email_auto_corrected_from;
 
         return $this;
     }
@@ -303,7 +634,7 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     /**
      * Gets address_signals
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\AddressSignals|null
+     * @return \OpenAPI\FraudIntel\Client\Model\AddressSignals
      */
     public function getAddressSignals()
     {
@@ -313,7 +644,7 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     /**
      * Sets address_signals
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\AddressSignals|null  $address_signals  address_signals
+     * @param  \OpenAPI\FraudIntel\Client\Model\AddressSignals  $address_signals  Local-part parsing details for the analyzed address.
      * @return self
      */
     public function setAddressSignals($address_signals)
@@ -327,53 +658,27 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     }
 
     /**
-     * Gets dns
+     * Gets email_dns
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\EmailDNS|null
+     * @return \OpenAPI\FraudIntel\Client\Model\EmailDNS
      */
-    public function getDns()
+    public function getEmailDns()
     {
-        return $this->container['dns'];
+        return $this->container['email_dns'];
     }
 
     /**
-     * Sets dns
+     * Sets email_dns
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\EmailDNS|null  $dns  dns
+     * @param  \OpenAPI\FraudIntel\Client\Model\EmailDNS  $email_dns  email_dns
      * @return self
      */
-    public function setDns($dns)
+    public function setEmailDns($email_dns)
     {
-        if (is_null($dns)) {
-            throw new \InvalidArgumentException('non-nullable dns cannot be null');
+        if (is_null($email_dns)) {
+            throw new \InvalidArgumentException('non-nullable email_dns cannot be null');
         }
-        $this->container['dns'] = $dns;
-
-        return $this;
-    }
-
-    /**
-     * Gets domain
-     *
-     * @return \OpenAPI\FraudIntel\Client\Model\EmailDomain|null
-     */
-    public function getDomain()
-    {
-        return $this->container['domain'];
-    }
-
-    /**
-     * Sets domain
-     *
-     * @param  \OpenAPI\FraudIntel\Client\Model\EmailDomain|null  $domain  domain
-     * @return self
-     */
-    public function setDomain($domain)
-    {
-        if (is_null($domain)) {
-            throw new \InvalidArgumentException('non-nullable domain cannot be null');
-        }
-        $this->container['domain'] = $domain;
+        $this->container['email_dns'] = $email_dns;
 
         return $this;
     }
@@ -391,7 +696,7 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
     /**
      * Sets risk_report
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReportEmail|null  $risk_report  AI risk report. Present when `enableAI` is `true`.
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReportEmail|null  $risk_report  Risk report from Email Insights analysis.
      * @return self
      */
     public function setRiskReport($risk_report)
@@ -400,6 +705,32 @@ class AnalyzeFraud200ResponseSourcesEmail implements \JsonSerializable, ArrayAcc
             throw new \InvalidArgumentException('non-nullable risk_report cannot be null');
         }
         $this->container['risk_report'] = $risk_report;
+
+        return $this;
+    }
+
+    /**
+     * Gets domain
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\EmailDomain|null
+     */
+    public function getDomain()
+    {
+        return $this->container['domain'];
+    }
+
+    /**
+     * Sets domain
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\EmailDomain|null  $domain  Domain summary derived from enrichment providers.
+     * @return self
+     */
+    public function setDomain($domain)
+    {
+        if (is_null($domain)) {
+            throw new \InvalidArgumentException('non-nullable domain cannot be null');
+        }
+        $this->container['domain'] = $domain;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesGeo.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesGeo.php
@@ -26,6 +26,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static $openAPITypes = [
         'consistent' => 'bool',
         'signals' => '\OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesGeoSignals',
+        'risk_report' => '\OpenAPI\FraudIntel\Client\Model\RiskReport',
     ];
 
     /**
@@ -40,6 +41,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static $openAPIFormats = [
         'consistent' => null,
         'signals' => null,
+        'risk_report' => null,
     ];
 
     /**
@@ -50,6 +52,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static array $openAPINullables = [
         'consistent' => false,
         'signals' => false,
+        'risk_report' => false,
     ];
 
     /**
@@ -132,6 +135,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static $attributeMap = [
         'consistent' => 'consistent',
         'signals' => 'signals',
+        'risk_report' => 'riskReport',
     ];
 
     /**
@@ -142,6 +146,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static $setters = [
         'consistent' => 'setConsistent',
         'signals' => 'setSignals',
+        'risk_report' => 'setRiskReport',
     ];
 
     /**
@@ -152,6 +157,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     protected static $getters = [
         'consistent' => 'getConsistent',
         'signals' => 'getSignals',
+        'risk_report' => 'getRiskReport',
     ];
 
     /**
@@ -212,6 +218,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     {
         $this->setIfExists('consistent', $data ?? [], null);
         $this->setIfExists('signals', $data ?? [], null);
+        $this->setIfExists('risk_report', $data ?? [], null);
     }
 
     /**
@@ -239,6 +246,16 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     {
         $invalidProperties = [];
 
+        if ($this->container['consistent'] === null) {
+            $invalidProperties[] = "'consistent' can't be null";
+        }
+        if ($this->container['signals'] === null) {
+            $invalidProperties[] = "'signals' can't be null";
+        }
+        if ($this->container['risk_report'] === null) {
+            $invalidProperties[] = "'risk_report' can't be null";
+        }
+
         return $invalidProperties;
     }
 
@@ -256,7 +273,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     /**
      * Gets consistent
      *
-     * @return bool|null
+     * @return bool
      */
     public function getConsistent()
     {
@@ -266,7 +283,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     /**
      * Sets consistent
      *
-     * @param  bool|null  $consistent  True when the email domain country and the IP geolocation country are consistent.
+     * @param  bool  $consistent  True when all available geographic signals resolve to the same country code.
      * @return self
      */
     public function setConsistent($consistent)
@@ -282,7 +299,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     /**
      * Gets signals
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesGeoSignals|null
+     * @return \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesGeoSignals
      */
     public function getSignals()
     {
@@ -292,7 +309,7 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
     /**
      * Sets signals
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesGeoSignals|null  $signals  signals
+     * @param  \OpenAPI\FraudIntel\Client\Model\AnalyzeFraud200ResponseSourcesGeoSignals  $signals  signals
      * @return self
      */
     public function setSignals($signals)
@@ -301,6 +318,32 @@ class AnalyzeFraud200ResponseSourcesGeo implements \JsonSerializable, ArrayAcces
             throw new \InvalidArgumentException('non-nullable signals cannot be null');
         }
         $this->container['signals'] = $signals;
+
+        return $this;
+    }
+
+    /**
+     * Gets risk_report
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\RiskReport
+     */
+    public function getRiskReport()
+    {
+        return $this->container['risk_report'];
+    }
+
+    /**
+     * Sets risk_report
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReport  $risk_report  Risk report for geographic consistency. Score is elevated when signals are inconsistent.
+     * @return self
+     */
+    public function setRiskReport($risk_report)
+    {
+        if (is_null($risk_report)) {
+            throw new \InvalidArgumentException('non-nullable risk_report cannot be null');
+        }
+        $this->container['risk_report'] = $risk_report;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesIp.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesIp.php
@@ -25,11 +25,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static $openAPITypes = [
         'ip_address' => 'string',
+        'ip_address_number' => 'int',
+        'ip_type' => 'string',
+        'ip_cidr' => 'string',
         'connection_type' => 'string',
+        'host_reverse' => 'string',
         'geo' => '\OpenAPI\FraudIntel\Client\Model\Geo',
-        'blocklisted' => '\OpenAPI\FraudIntel\Client\Model\BlockListed',
-        'trusted_provider' => '\OpenAPI\FraudIntel\Client\Model\TrustedProvider',
         'whois' => '\OpenAPI\FraudIntel\Client\Model\Whois',
+        'trusted_provider' => '\OpenAPI\FraudIntel\Client\Model\TrustedProvider',
+        'blocklisted' => '\OpenAPI\FraudIntel\Client\Model\BlockListed',
         'risk_report' => '\OpenAPI\FraudIntel\Client\Model\RiskReportIp',
     ];
 
@@ -44,11 +48,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static $openAPIFormats = [
         'ip_address' => null,
+        'ip_address_number' => null,
+        'ip_type' => null,
+        'ip_cidr' => null,
         'connection_type' => null,
+        'host_reverse' => null,
         'geo' => null,
-        'blocklisted' => null,
-        'trusted_provider' => null,
         'whois' => null,
+        'trusted_provider' => null,
+        'blocklisted' => null,
         'risk_report' => null,
     ];
 
@@ -59,11 +67,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static array $openAPINullables = [
         'ip_address' => false,
+        'ip_address_number' => false,
+        'ip_type' => false,
+        'ip_cidr' => false,
         'connection_type' => false,
+        'host_reverse' => false,
         'geo' => false,
-        'blocklisted' => false,
-        'trusted_provider' => false,
         'whois' => false,
+        'trusted_provider' => false,
+        'blocklisted' => false,
         'risk_report' => false,
     ];
 
@@ -146,11 +158,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static $attributeMap = [
         'ip_address' => 'ipAddress',
+        'ip_address_number' => 'ipAddressNumber',
+        'ip_type' => 'ipType',
+        'ip_cidr' => 'ipCidr',
         'connection_type' => 'connectionType',
+        'host_reverse' => 'hostReverse',
         'geo' => 'geo',
-        'blocklisted' => 'blocklisted',
-        'trusted_provider' => 'trustedProvider',
         'whois' => 'whois',
+        'trusted_provider' => 'trustedProvider',
+        'blocklisted' => 'blocklisted',
         'risk_report' => 'riskReport',
     ];
 
@@ -161,11 +177,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static $setters = [
         'ip_address' => 'setIpAddress',
+        'ip_address_number' => 'setIpAddressNumber',
+        'ip_type' => 'setIpType',
+        'ip_cidr' => 'setIpCidr',
         'connection_type' => 'setConnectionType',
+        'host_reverse' => 'setHostReverse',
         'geo' => 'setGeo',
-        'blocklisted' => 'setBlocklisted',
-        'trusted_provider' => 'setTrustedProvider',
         'whois' => 'setWhois',
+        'trusted_provider' => 'setTrustedProvider',
+        'blocklisted' => 'setBlocklisted',
         'risk_report' => 'setRiskReport',
     ];
 
@@ -176,11 +196,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
      */
     protected static $getters = [
         'ip_address' => 'getIpAddress',
+        'ip_address_number' => 'getIpAddressNumber',
+        'ip_type' => 'getIpType',
+        'ip_cidr' => 'getIpCidr',
         'connection_type' => 'getConnectionType',
+        'host_reverse' => 'getHostReverse',
         'geo' => 'getGeo',
-        'blocklisted' => 'getBlocklisted',
-        'trusted_provider' => 'getTrustedProvider',
         'whois' => 'getWhois',
+        'trusted_provider' => 'getTrustedProvider',
+        'blocklisted' => 'getBlocklisted',
         'risk_report' => 'getRiskReport',
     ];
 
@@ -241,11 +265,15 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     public function __construct(?array $data = null)
     {
         $this->setIfExists('ip_address', $data ?? [], null);
+        $this->setIfExists('ip_address_number', $data ?? [], null);
+        $this->setIfExists('ip_type', $data ?? [], null);
+        $this->setIfExists('ip_cidr', $data ?? [], null);
         $this->setIfExists('connection_type', $data ?? [], null);
+        $this->setIfExists('host_reverse', $data ?? [], null);
         $this->setIfExists('geo', $data ?? [], null);
-        $this->setIfExists('blocklisted', $data ?? [], null);
-        $this->setIfExists('trusted_provider', $data ?? [], null);
         $this->setIfExists('whois', $data ?? [], null);
+        $this->setIfExists('trusted_provider', $data ?? [], null);
+        $this->setIfExists('blocklisted', $data ?? [], null);
         $this->setIfExists('risk_report', $data ?? [], null);
     }
 
@@ -274,6 +302,40 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     {
         $invalidProperties = [];
 
+        if ($this->container['ip_address'] === null) {
+            $invalidProperties[] = "'ip_address' can't be null";
+        }
+        if ($this->container['ip_address_number'] === null) {
+            $invalidProperties[] = "'ip_address_number' can't be null";
+        }
+        if ($this->container['ip_type'] === null) {
+            $invalidProperties[] = "'ip_type' can't be null";
+        }
+        if ($this->container['ip_cidr'] === null) {
+            $invalidProperties[] = "'ip_cidr' can't be null";
+        }
+        if ($this->container['connection_type'] === null) {
+            $invalidProperties[] = "'connection_type' can't be null";
+        }
+        if ($this->container['host_reverse'] === null) {
+            $invalidProperties[] = "'host_reverse' can't be null";
+        }
+        if ($this->container['geo'] === null) {
+            $invalidProperties[] = "'geo' can't be null";
+        }
+        if ($this->container['whois'] === null) {
+            $invalidProperties[] = "'whois' can't be null";
+        }
+        if ($this->container['trusted_provider'] === null) {
+            $invalidProperties[] = "'trusted_provider' can't be null";
+        }
+        if ($this->container['blocklisted'] === null) {
+            $invalidProperties[] = "'blocklisted' can't be null";
+        }
+        if ($this->container['risk_report'] === null) {
+            $invalidProperties[] = "'risk_report' can't be null";
+        }
+
         return $invalidProperties;
     }
 
@@ -291,7 +353,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Gets ip_address
      *
-     * @return string|null
+     * @return string
      */
     public function getIpAddress()
     {
@@ -301,7 +363,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Sets ip_address
      *
-     * @param  string|null  $ip_address  The analyzed IP address.
+     * @param  string  $ip_address  The analyzed IP address.
      * @return self
      */
     public function setIpAddress($ip_address)
@@ -315,9 +377,87 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     }
 
     /**
+     * Gets ip_address_number
+     *
+     * @return int
+     */
+    public function getIpAddressNumber()
+    {
+        return $this->container['ip_address_number'];
+    }
+
+    /**
+     * Sets ip_address_number
+     *
+     * @param  int  $ip_address_number  Numeric representation of the IP address.
+     * @return self
+     */
+    public function setIpAddressNumber($ip_address_number)
+    {
+        if (is_null($ip_address_number)) {
+            throw new \InvalidArgumentException('non-nullable ip_address_number cannot be null');
+        }
+        $this->container['ip_address_number'] = $ip_address_number;
+
+        return $this;
+    }
+
+    /**
+     * Gets ip_type
+     *
+     * @return string
+     */
+    public function getIpType()
+    {
+        return $this->container['ip_type'];
+    }
+
+    /**
+     * Sets ip_type
+     *
+     * @param  string  $ip_type  Type of the IP address (IPv4 or IPv6).
+     * @return self
+     */
+    public function setIpType($ip_type)
+    {
+        if (is_null($ip_type)) {
+            throw new \InvalidArgumentException('non-nullable ip_type cannot be null');
+        }
+        $this->container['ip_type'] = $ip_type;
+
+        return $this;
+    }
+
+    /**
+     * Gets ip_cidr
+     *
+     * @return string
+     */
+    public function getIpCidr()
+    {
+        return $this->container['ip_cidr'];
+    }
+
+    /**
+     * Sets ip_cidr
+     *
+     * @param  string  $ip_cidr  CIDR notation of the IP address.
+     * @return self
+     */
+    public function setIpCidr($ip_cidr)
+    {
+        if (is_null($ip_cidr)) {
+            throw new \InvalidArgumentException('non-nullable ip_cidr cannot be null');
+        }
+        $this->container['ip_cidr'] = $ip_cidr;
+
+        return $this;
+    }
+
+    /**
      * Gets connection_type
      *
-     * @return string|null
+     * @return string
      */
     public function getConnectionType()
     {
@@ -327,7 +467,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Sets connection_type
      *
-     * @param  string|null  $connection_type  Detected connection type.
+     * @param  string  $connection_type  The type of connection associated with the IP address. Allowed values: `wired`, `mobile`, `enterprise`, `satellite`, `vpn`, `cloud-provider`, `open-proxy`, `tor`.
      * @return self
      */
     public function setConnectionType($connection_type)
@@ -341,9 +481,35 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     }
 
     /**
+     * Gets host_reverse
+     *
+     * @return string
+     */
+    public function getHostReverse()
+    {
+        return $this->container['host_reverse'];
+    }
+
+    /**
+     * Sets host_reverse
+     *
+     * @param  string  $host_reverse  Real time reverse DNS lookup result for the IP address.
+     * @return self
+     */
+    public function setHostReverse($host_reverse)
+    {
+        if (is_null($host_reverse)) {
+            throw new \InvalidArgumentException('non-nullable host_reverse cannot be null');
+        }
+        $this->container['host_reverse'] = $host_reverse;
+
+        return $this;
+    }
+
+    /**
      * Gets geo
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\Geo|null
+     * @return \OpenAPI\FraudIntel\Client\Model\Geo
      */
     public function getGeo()
     {
@@ -353,7 +519,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Sets geo
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\Geo|null  $geo  geo
+     * @param  \OpenAPI\FraudIntel\Client\Model\Geo  $geo  geo
      * @return self
      */
     public function setGeo($geo)
@@ -367,61 +533,9 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     }
 
     /**
-     * Gets blocklisted
-     *
-     * @return \OpenAPI\FraudIntel\Client\Model\BlockListed|null
-     */
-    public function getBlocklisted()
-    {
-        return $this->container['blocklisted'];
-    }
-
-    /**
-     * Sets blocklisted
-     *
-     * @param  \OpenAPI\FraudIntel\Client\Model\BlockListed|null  $blocklisted  blocklisted
-     * @return self
-     */
-    public function setBlocklisted($blocklisted)
-    {
-        if (is_null($blocklisted)) {
-            throw new \InvalidArgumentException('non-nullable blocklisted cannot be null');
-        }
-        $this->container['blocklisted'] = $blocklisted;
-
-        return $this;
-    }
-
-    /**
-     * Gets trusted_provider
-     *
-     * @return \OpenAPI\FraudIntel\Client\Model\TrustedProvider|null
-     */
-    public function getTrustedProvider()
-    {
-        return $this->container['trusted_provider'];
-    }
-
-    /**
-     * Sets trusted_provider
-     *
-     * @param  \OpenAPI\FraudIntel\Client\Model\TrustedProvider|null  $trusted_provider  trusted_provider
-     * @return self
-     */
-    public function setTrustedProvider($trusted_provider)
-    {
-        if (is_null($trusted_provider)) {
-            throw new \InvalidArgumentException('non-nullable trusted_provider cannot be null');
-        }
-        $this->container['trusted_provider'] = $trusted_provider;
-
-        return $this;
-    }
-
-    /**
      * Gets whois
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\Whois|null
+     * @return \OpenAPI\FraudIntel\Client\Model\Whois
      */
     public function getWhois()
     {
@@ -431,7 +545,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Sets whois
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\Whois|null  $whois  whois
+     * @param  \OpenAPI\FraudIntel\Client\Model\Whois  $whois  whois
      * @return self
      */
     public function setWhois($whois)
@@ -445,9 +559,61 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     }
 
     /**
+     * Gets trusted_provider
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\TrustedProvider
+     */
+    public function getTrustedProvider()
+    {
+        return $this->container['trusted_provider'];
+    }
+
+    /**
+     * Sets trusted_provider
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\TrustedProvider  $trusted_provider  trusted_provider
+     * @return self
+     */
+    public function setTrustedProvider($trusted_provider)
+    {
+        if (is_null($trusted_provider)) {
+            throw new \InvalidArgumentException('non-nullable trusted_provider cannot be null');
+        }
+        $this->container['trusted_provider'] = $trusted_provider;
+
+        return $this;
+    }
+
+    /**
+     * Gets blocklisted
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\BlockListed
+     */
+    public function getBlocklisted()
+    {
+        return $this->container['blocklisted'];
+    }
+
+    /**
+     * Sets blocklisted
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\BlockListed  $blocklisted  blocklisted
+     * @return self
+     */
+    public function setBlocklisted($blocklisted)
+    {
+        if (is_null($blocklisted)) {
+            throw new \InvalidArgumentException('non-nullable blocklisted cannot be null');
+        }
+        $this->container['blocklisted'] = $blocklisted;
+
+        return $this;
+    }
+
+    /**
      * Gets risk_report
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\RiskReportIp|null
+     * @return \OpenAPI\FraudIntel\Client\Model\RiskReportIp
      */
     public function getRiskReport()
     {
@@ -457,7 +623,7 @@ class AnalyzeFraud200ResponseSourcesIp implements \JsonSerializable, ArrayAccess
     /**
      * Sets risk_report
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReportIp|null  $risk_report  AI risk report. Present when `enableAI` is `true`.
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReportIp  $risk_report  Risk report from IP Insights analysis.
      * @return self
      */
     public function setRiskReport($risk_report)

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesSession.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesSession.php
@@ -30,6 +30,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => 'float',
         'token_valid' => 'bool',
         'detections' => '\OpenAPI\FraudIntel\Client\Model\FraudAnalyzeSessionDetectionsInner[]',
+        'score' => 'int',
+        'level' => 'string',
+        'factors' => 'string[]',
+        'event_count' => 'int',
+        'risk_report' => '\OpenAPI\FraudIntel\Client\Model\RiskReport',
     ];
 
     /**
@@ -48,6 +53,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => null,
         'token_valid' => null,
         'detections' => null,
+        'score' => null,
+        'level' => null,
+        'factors' => null,
+        'event_count' => null,
+        'risk_report' => null,
     ];
 
     /**
@@ -62,6 +72,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => false,
         'token_valid' => false,
         'detections' => false,
+        'score' => false,
+        'level' => false,
+        'factors' => false,
+        'event_count' => false,
+        'risk_report' => false,
     ];
 
     /**
@@ -148,6 +163,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => 'tokenAge',
         'token_valid' => 'tokenValid',
         'detections' => 'detections',
+        'score' => 'score',
+        'level' => 'level',
+        'factors' => 'factors',
+        'event_count' => 'eventCount',
+        'risk_report' => 'riskReport',
     ];
 
     /**
@@ -162,6 +182,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => 'setTokenAge',
         'token_valid' => 'setTokenValid',
         'detections' => 'setDetections',
+        'score' => 'setScore',
+        'level' => 'setLevel',
+        'factors' => 'setFactors',
+        'event_count' => 'setEventCount',
+        'risk_report' => 'setRiskReport',
     ];
 
     /**
@@ -176,6 +201,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         'token_age' => 'getTokenAge',
         'token_valid' => 'getTokenValid',
         'detections' => 'getDetections',
+        'score' => 'getScore',
+        'level' => 'getLevel',
+        'factors' => 'getFactors',
+        'event_count' => 'getEventCount',
+        'risk_report' => 'getRiskReport',
     ];
 
     /**
@@ -240,6 +270,11 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
         $this->setIfExists('token_age', $data ?? [], null);
         $this->setIfExists('token_valid', $data ?? [], null);
         $this->setIfExists('detections', $data ?? [], null);
+        $this->setIfExists('score', $data ?? [], null);
+        $this->setIfExists('level', $data ?? [], null);
+        $this->setIfExists('factors', $data ?? [], null);
+        $this->setIfExists('event_count', $data ?? [], null);
+        $this->setIfExists('risk_report', $data ?? [], null);
     }
 
     /**
@@ -433,6 +468,136 @@ class AnalyzeFraud200ResponseSourcesSession implements \JsonSerializable, ArrayA
             throw new \InvalidArgumentException('non-nullable detections cannot be null');
         }
         $this->container['detections'] = $detections;
+
+        return $this;
+    }
+
+    /**
+     * Gets score
+     *
+     * @return int|null
+     */
+    public function getScore()
+    {
+        return $this->container['score'];
+    }
+
+    /**
+     * Sets score
+     *
+     * @param  int|null  $score  Composite session risk score normalized to 200–1000. Present when behavioral analysis produced a session risk score.
+     * @return self
+     */
+    public function setScore($score)
+    {
+        if (is_null($score)) {
+            throw new \InvalidArgumentException('non-nullable score cannot be null');
+        }
+        $this->container['score'] = $score;
+
+        return $this;
+    }
+
+    /**
+     * Gets level
+     *
+     * @return string|null
+     */
+    public function getLevel()
+    {
+        return $this->container['level'];
+    }
+
+    /**
+     * Sets level
+     *
+     * @param  string|null  $level  Risk level derived from session behavioral analysis. Allowed values: lowest, low, medium, high, highest.
+     * @return self
+     */
+    public function setLevel($level)
+    {
+        if (is_null($level)) {
+            throw new \InvalidArgumentException('non-nullable level cannot be null');
+        }
+        $this->container['level'] = $level;
+
+        return $this;
+    }
+
+    /**
+     * Gets factors
+     *
+     * @return string[]|null
+     */
+    public function getFactors()
+    {
+        return $this->container['factors'];
+    }
+
+    /**
+     * Sets factors
+     *
+     * @param  string[]|null  $factors  Factor codes contributing to the session risk score. Values follow the `session:factor-code` format.
+     * @return self
+     */
+    public function setFactors($factors)
+    {
+        if (is_null($factors)) {
+            throw new \InvalidArgumentException('non-nullable factors cannot be null');
+        }
+        $this->container['factors'] = $factors;
+
+        return $this;
+    }
+
+    /**
+     * Gets event_count
+     *
+     * @return int|null
+     */
+    public function getEventCount()
+    {
+        return $this->container['event_count'];
+    }
+
+    /**
+     * Sets event_count
+     *
+     * @param  int|null  $event_count  Number of telemetry events recorded for this session.
+     * @return self
+     */
+    public function setEventCount($event_count)
+    {
+        if (is_null($event_count)) {
+            throw new \InvalidArgumentException('non-nullable event_count cannot be null');
+        }
+        $this->container['event_count'] = $event_count;
+
+        return $this;
+    }
+
+    /**
+     * Gets risk_report
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\RiskReport|null
+     */
+    public function getRiskReport()
+    {
+        return $this->container['risk_report'];
+    }
+
+    /**
+     * Sets risk_report
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReport|null  $risk_report  Risk report from session behavioral analysis.
+     * @return self
+     */
+    public function setRiskReport($risk_report)
+    {
+        if (is_null($risk_report)) {
+            throw new \InvalidArgumentException('non-nullable risk_report cannot be null');
+        }
+        $this->container['risk_report'] = $risk_report;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesVelocity.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraud200ResponseSourcesVelocity.php
@@ -28,6 +28,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => '\OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow',
         'phone_submissions' => '\OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow',
         'anomaly' => 'bool',
+        'risk_report' => '\OpenAPI\FraudIntel\Client\Model\RiskReport',
     ];
 
     /**
@@ -44,6 +45,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => null,
         'phone_submissions' => null,
         'anomaly' => null,
+        'risk_report' => null,
     ];
 
     /**
@@ -56,6 +58,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => true,
         'phone_submissions' => true,
         'anomaly' => false,
+        'risk_report' => false,
     ];
 
     /**
@@ -140,6 +143,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => 'ipSubmissions',
         'phone_submissions' => 'phoneSubmissions',
         'anomaly' => 'anomaly',
+        'risk_report' => 'riskReport',
     ];
 
     /**
@@ -152,6 +156,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => 'setIpSubmissions',
         'phone_submissions' => 'setPhoneSubmissions',
         'anomaly' => 'setAnomaly',
+        'risk_report' => 'setRiskReport',
     ];
 
     /**
@@ -164,6 +169,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         'ip_submissions' => 'getIpSubmissions',
         'phone_submissions' => 'getPhoneSubmissions',
         'anomaly' => 'getAnomaly',
+        'risk_report' => 'getRiskReport',
     ];
 
     /**
@@ -226,6 +232,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
         $this->setIfExists('ip_submissions', $data ?? [], null);
         $this->setIfExists('phone_submissions', $data ?? [], null);
         $this->setIfExists('anomaly', $data ?? [], null);
+        $this->setIfExists('risk_report', $data ?? [], null);
     }
 
     /**
@@ -253,6 +260,22 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     {
         $invalidProperties = [];
 
+        if ($this->container['email_submissions'] === null) {
+            $invalidProperties[] = "'email_submissions' can't be null";
+        }
+        if ($this->container['ip_submissions'] === null) {
+            $invalidProperties[] = "'ip_submissions' can't be null";
+        }
+        if ($this->container['phone_submissions'] === null) {
+            $invalidProperties[] = "'phone_submissions' can't be null";
+        }
+        if ($this->container['anomaly'] === null) {
+            $invalidProperties[] = "'anomaly' can't be null";
+        }
+        if ($this->container['risk_report'] === null) {
+            $invalidProperties[] = "'risk_report' can't be null";
+        }
+
         return $invalidProperties;
     }
 
@@ -270,7 +293,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Gets email_submissions
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null
+     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow
      */
     public function getEmailSubmissions()
     {
@@ -280,7 +303,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Sets email_submissions
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null  $email_submissions  email_submissions
+     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow  $email_submissions  email_submissions
      * @return self
      */
     public function setEmailSubmissions($email_submissions)
@@ -303,7 +326,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Gets ip_submissions
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null
+     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow
      */
     public function getIpSubmissions()
     {
@@ -313,7 +336,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Sets ip_submissions
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null  $ip_submissions  ip_submissions
+     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow  $ip_submissions  ip_submissions
      * @return self
      */
     public function setIpSubmissions($ip_submissions)
@@ -336,7 +359,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Gets phone_submissions
      *
-     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null
+     * @return \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow
      */
     public function getPhoneSubmissions()
     {
@@ -346,7 +369,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Sets phone_submissions
      *
-     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow|null  $phone_submissions  phone_submissions
+     * @param  \OpenAPI\FraudIntel\Client\Model\FraudVelocityWindow  $phone_submissions  phone_submissions
      * @return self
      */
     public function setPhoneSubmissions($phone_submissions)
@@ -369,7 +392,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Gets anomaly
      *
-     * @return bool|null
+     * @return bool
      */
     public function getAnomaly()
     {
@@ -379,7 +402,7 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
     /**
      * Sets anomaly
      *
-     * @param  bool|null  $anomaly  True when any identifier's submission rate exceeds the configured anomaly threshold.
+     * @param  bool  $anomaly  True when any identifier's submission rate exceeds the configured anomaly threshold.
      * @return self
      */
     public function setAnomaly($anomaly)
@@ -388,6 +411,32 @@ class AnalyzeFraud200ResponseSourcesVelocity implements \JsonSerializable, Array
             throw new \InvalidArgumentException('non-nullable anomaly cannot be null');
         }
         $this->container['anomaly'] = $anomaly;
+
+        return $this;
+    }
+
+    /**
+     * Gets risk_report
+     *
+     * @return \OpenAPI\FraudIntel\Client\Model\RiskReport
+     */
+    public function getRiskReport()
+    {
+        return $this->container['risk_report'];
+    }
+
+    /**
+     * Sets risk_report
+     *
+     * @param  \OpenAPI\FraudIntel\Client\Model\RiskReport  $risk_report  Risk report for velocity signals. Score is elevated when `anomaly` is `true`.
+     * @return self
+     */
+    public function setRiskReport($risk_report)
+    {
+        if (is_null($risk_report)) {
+            throw new \InvalidArgumentException('non-nullable risk_report cannot be null');
+        }
+        $this->container['risk_report'] = $risk_report;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/AnalyzeFraudRequest.php
+++ b/lib/fraud-intel/lib/Model/AnalyzeFraudRequest.php
@@ -47,7 +47,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => 'array<string,mixed>',
         'opportify_token' => 'string',
         'opportify_form_uuid' => 'string',
-        'enable_ai' => 'bool',
     ];
 
     /**
@@ -83,7 +82,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => null,
         'opportify_token' => null,
         'opportify_form_uuid' => null,
-        'enable_ai' => null,
     ];
 
     /**
@@ -115,7 +113,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => false,
         'opportify_token' => false,
         'opportify_form_uuid' => false,
-        'enable_ai' => false,
     ];
 
     /**
@@ -219,7 +216,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => 'formData',
         'opportify_token' => 'opportifyToken',
         'opportify_form_uuid' => 'opportifyFormUUID',
-        'enable_ai' => 'enableAI',
     ];
 
     /**
@@ -251,7 +247,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => 'setFormData',
         'opportify_token' => 'setOpportifyToken',
         'opportify_form_uuid' => 'setOpportifyFormUuid',
-        'enable_ai' => 'setEnableAi',
     ];
 
     /**
@@ -283,7 +278,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         'form_data' => 'getFormData',
         'opportify_token' => 'getOpportifyToken',
         'opportify_form_uuid' => 'getOpportifyFormUuid',
-        'enable_ai' => 'getEnableAi',
     ];
 
     /**
@@ -365,7 +359,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
         $this->setIfExists('form_data', $data ?? [], null);
         $this->setIfExists('opportify_token', $data ?? [], null);
         $this->setIfExists('opportify_form_uuid', $data ?? [], null);
-        $this->setIfExists('enable_ai', $data ?? [], null);
     }
 
     /**
@@ -393,7 +386,7 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
     {
         $invalidProperties = [];
 
-        if (!is_null($this->container['email']) && (mb_strlen($this->container['email']) > 320)) {
+        if (! is_null($this->container['email']) && (mb_strlen($this->container['email']) > 320)) {
             $invalidProperties[] = "invalid value for 'email', the character length must be smaller than or equal to 320.";
         }
 
@@ -1009,32 +1002,6 @@ class AnalyzeFraudRequest implements \JsonSerializable, ArrayAccess, ModelInterf
             throw new \InvalidArgumentException('non-nullable opportify_form_uuid cannot be null');
         }
         $this->container['opportify_form_uuid'] = $opportify_form_uuid;
-
-        return $this;
-    }
-
-    /**
-     * Gets enable_ai
-     *
-     * @return bool|null
-     */
-    public function getEnableAi()
-    {
-        return $this->container['enable_ai'];
-    }
-
-    /**
-     * Sets enable_ai
-     *
-     * @param  bool|null  $enable_ai  Enable AI-driven composite risk scoring. When `true`, the response includes `score`, `level`, and `factors`. Defaults to `true`.
-     * @return self
-     */
-    public function setEnableAi($enable_ai)
-    {
-        if (is_null($enable_ai)) {
-            throw new \InvalidArgumentException('non-nullable enable_ai cannot be null');
-        }
-        $this->container['enable_ai'] = $enable_ai;
 
         return $this;
     }

--- a/lib/fraud-intel/lib/Model/RiskReportEmail.php
+++ b/lib/fraud-intel/lib/Model/RiskReportEmail.php
@@ -246,11 +246,11 @@ class RiskReportEmail implements \JsonSerializable, ArrayAccess, ModelInterface
     {
         $invalidProperties = [];
 
-        if (!is_null($this->container['score']) && ($this->container['score'] > 1000)) {
+        if (! is_null($this->container['score']) && ($this->container['score'] > 1000)) {
             $invalidProperties[] = "invalid value for 'score', must be smaller than or equal to 1000.";
         }
 
-        if (!is_null($this->container['score']) && ($this->container['score'] < 200)) {
+        if (! is_null($this->container['score']) && ($this->container['score'] < 200)) {
             $invalidProperties[] = "invalid value for 'score', must be bigger than or equal to 200.";
         }
 

--- a/lib/fraud-intel/lib/ObjectSerializer.php
+++ b/lib/fraud-intel/lib/ObjectSerializer.php
@@ -55,12 +55,12 @@ class ObjectSerializer
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
-                    if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+                    if ($value !== null && ! in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
                         $callable = [$openAPIType, 'getAllowableEnumValues'];
                         if (is_callable($callable)) {
                             /** array $callable */
                             $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
+                            if (! in_array($value, $allowedEnumTypes, true)) {
                                 $imploded = implode("', '", $allowedEnumTypes);
                                 throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
                             }
@@ -106,7 +106,7 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) {
+        if (! is_string($timestamp)) {
             return $timestamp;
         }
 
@@ -134,7 +134,7 @@ class ObjectSerializer
     private static function isEmptyValue($value, string $openApiType): bool
     {
         // If empty() returns false, it is not empty regardless of its type.
-        if (!empty($value)) {
+        if (! empty($value)) {
             return false;
         }
 
@@ -158,7 +158,7 @@ class ObjectSerializer
                 // For boolean values, '' is considered empty
             case 'bool':
             case 'boolean':
-                return !in_array($value, [false, 0], true);
+                return ! in_array($value, [false, 0], true);
 
                 // For string values, '' is considered empty.
             case 'string':
@@ -213,7 +213,7 @@ class ObjectSerializer
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first
         $flattenArray = function ($arr, $name, &$result = []) use (&$flattenArray, $style, $explode) {
-            if (!is_array($arr)) {
+            if (! is_array($arr)) {
                 return $arr;
             }
 
@@ -223,7 +223,7 @@ class ObjectSerializer
                 if (is_array($v)) {
                     $flattenArray($v, $prop, $result);
                 } else {
-                    if ($style !== 'deepObject' && !$explode) {
+                    if ($style !== 'deepObject' && ! $explode) {
                         // push key itself
                         $result[] = $prop;
                     }
@@ -361,7 +361,7 @@ class ObjectSerializer
         if (strcasecmp(substr($class, -2), '[]') === 0) {
             $data = is_string($data) ? json_decode($data) : $data;
 
-            if (!is_array($data)) {
+            if (! is_array($data)) {
                 throw new \InvalidArgumentException("Invalid array '$class'");
             }
 
@@ -407,7 +407,7 @@ class ObjectSerializer
             // what is meant. The invalid empty string is probably to
             // be interpreted as a missing field/value. Let's handle
             // this graceful.
-            if (!empty($data)) {
+            if (! empty($data)) {
                 try {
                     return new \DateTime($data);
                 } catch (\Exception $exception) {
@@ -454,7 +454,7 @@ class ObjectSerializer
         }
 
         if (method_exists($class, 'getAllowableEnumValues')) {
-            if (!in_array($data, $class::getAllowableEnumValues(), true)) {
+            if (! in_array($data, $class::getAllowableEnumValues(), true)) {
                 $imploded = implode("', '", $class::getAllowableEnumValues());
                 throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
@@ -469,7 +469,7 @@ class ObjectSerializer
 
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;
-            if (!empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {
+            if (! empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {
                 $subclass = '\OpenAPI\FraudIntel\Client\Model\\'.$data->{$discriminator};
                 if (is_subclass_of($subclass, $class)) {
                     $class = $subclass;
@@ -481,11 +481,11 @@ class ObjectSerializer
             foreach ($instance::openAPITypes() as $property => $type) {
                 $propertySetter = $instance::setters()[$property];
 
-                if (!isset($propertySetter)) {
+                if (! isset($propertySetter)) {
                     continue;
                 }
 
-                if (!isset($data->{$instance::attributeMap()[$property]})) {
+                if (! isset($data->{$instance::attributeMap()[$property]})) {
                     if ($instance::isNullable($property)) {
                         $instance->$propertySetter(null);
                     }
@@ -520,7 +520,7 @@ class ObjectSerializer
      */
     public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
     {
-        if (!$params) {
+        if (! $params) {
             return '';
         }
 
@@ -547,7 +547,7 @@ class ObjectSerializer
         $qs = '';
         foreach ($params as $k => $v) {
             $k = $encoder((string) $k);
-            if (!is_array($v)) {
+            if (! is_array($v)) {
                 $qs .= $k;
                 $v = is_bool($v) ? $castBool($v) : $v;
                 if ($v !== null) {

--- a/lib/v1/.php-cs-fixer.dist.php
+++ b/lib/v1/.php-cs-fixer.dist.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @generated
+ * @link https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/HEAD/doc/config.rst
+ */
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor')
+    ->exclude('test')
+    ->exclude('tests')
+;
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+        '@PSR12' => true,
+        'phpdoc_order' => true,
+        'array_syntax' => [ 'syntax' => 'short' ],
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'no_trailing_whitespace' => false,
+        'no_trailing_whitespace_in_comment' => false,
+        'braces' => false,
+        'single_blank_line_at_eof' => false,
+        'blank_line_after_namespace' => false,
+        'no_leading_import_slash' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/lib/v1/lib/Api/EmailInsightsApi.php
+++ b/lib/v1/lib/Api/EmailInsightsApi.php
@@ -1801,7 +1801,7 @@ class EmailInsightsApi
         $options = [];
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-            if (!$options[RequestOptions::DEBUG]) {
+            if (! $options[RequestOptions::DEBUG]) {
                 throw new \RuntimeException('Failed to open the debug file: '.$this->config->getDebugFile());
             }
         }

--- a/lib/v1/lib/Api/IPInsightsApi.php
+++ b/lib/v1/lib/Api/IPInsightsApi.php
@@ -1815,7 +1815,7 @@ class IPInsightsApi
         $options = [];
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-            if (!$options[RequestOptions::DEBUG]) {
+            if (! $options[RequestOptions::DEBUG]) {
                 throw new \RuntimeException('Failed to open the debug file: '.$this->config->getDebugFile());
             }
         }

--- a/lib/v1/lib/Configuration.php
+++ b/lib/v1/lib/Configuration.php
@@ -289,7 +289,7 @@ class Configuration
      */
     public function setUserAgent($userAgent)
     {
-        if (!is_string($userAgent)) {
+        if (! is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
         }
 
@@ -526,7 +526,7 @@ class Configuration
         // go through variable and assign a value
         foreach ($host['variables'] ?? [] as $name => $variable) {
             if (array_key_exists($name, $variables)) { // check to see if it's in the variables provided by the user
-                if (!isset($variable['enum_values']) || in_array($variables[$name], $variable['enum_values'], true)) { // check to see if the value is in the enum
+                if (! isset($variable['enum_values']) || in_array($variables[$name], $variable['enum_values'], true)) { // check to see if the value is in the enum
                     $url = str_replace('{'.$name.'}', $variables[$name], $url);
                 } else {
                     throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].'. Must be '.implode(',', $variable['enum_values']).'.');

--- a/lib/v1/lib/FormDataProcessor.php
+++ b/lib/v1/lib/FormDataProcessor.php
@@ -81,7 +81,7 @@ class FormDataProcessor
         foreach ($source as $key => $val) {
             $currentName .= $currentPrefix.$key;
 
-            if (is_array($val) && !empty($val)) {
+            if (is_array($val) && ! empty($val)) {
                 $currentName .= $currentSuffix;
                 $result += self::flatten($val, $currentName);
             } else {
@@ -123,7 +123,7 @@ class FormDataProcessor
             return $this->processModel($value);
         }
 
-        if (is_array($value) || (is_object($value) && !$value instanceof \DateTimeInterface)) {
+        if (is_array($value) || (is_object($value) && ! $value instanceof \DateTimeInterface)) {
             $data = [];
 
             foreach ($value as $k => $v) {

--- a/lib/v1/lib/HeaderSelector.php
+++ b/lib/v1/lib/HeaderSelector.php
@@ -19,7 +19,7 @@ class HeaderSelector
             $headers['Accept'] = $accept;
         }
 
-        if (!$isMultipart) {
+        if (! $isMultipart) {
             if ($contentType === '') {
                 $contentType = 'application/json';
             }

--- a/lib/v1/lib/Model/ExportRequest.php
+++ b/lib/v1/lib/Model/ExportRequest.php
@@ -246,7 +246,7 @@ class ExportRequest implements \JsonSerializable, ArrayAccess, ModelInterface
     {
         $invalidProperties = [];
 
-        if (!is_null($this->container['columns']) && (count($this->container['columns']) > 100)) {
+        if (! is_null($this->container['columns']) && (count($this->container['columns']) > 100)) {
             $invalidProperties[] = "invalid value for 'columns', number of items must be less than or equal to 100.";
         }
 

--- a/lib/v1/lib/Model/RiskReportEmail.php
+++ b/lib/v1/lib/Model/RiskReportEmail.php
@@ -246,11 +246,11 @@ class RiskReportEmail implements \JsonSerializable, ArrayAccess, ModelInterface
     {
         $invalidProperties = [];
 
-        if (!is_null($this->container['score']) && ($this->container['score'] > 1000)) {
+        if (! is_null($this->container['score']) && ($this->container['score'] > 1000)) {
             $invalidProperties[] = "invalid value for 'score', must be smaller than or equal to 1000.";
         }
 
-        if (!is_null($this->container['score']) && ($this->container['score'] < 200)) {
+        if (! is_null($this->container['score']) && ($this->container['score'] < 200)) {
             $invalidProperties[] = "invalid value for 'score', must be bigger than or equal to 200.";
         }
 

--- a/lib/v1/lib/ObjectSerializer.php
+++ b/lib/v1/lib/ObjectSerializer.php
@@ -55,12 +55,12 @@ class ObjectSerializer
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
-                    if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+                    if ($value !== null && ! in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
                         $callable = [$openAPIType, 'getAllowableEnumValues'];
                         if (is_callable($callable)) {
                             /** array $callable */
                             $allowedEnumTypes = $callable();
-                            if (!in_array($value, $allowedEnumTypes, true)) {
+                            if (! in_array($value, $allowedEnumTypes, true)) {
                                 $imploded = implode("', '", $allowedEnumTypes);
                                 throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
                             }
@@ -106,7 +106,7 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp($timestamp)
     {
-        if (!is_string($timestamp)) {
+        if (! is_string($timestamp)) {
             return $timestamp;
         }
 
@@ -134,7 +134,7 @@ class ObjectSerializer
     private static function isEmptyValue($value, string $openApiType): bool
     {
         // If empty() returns false, it is not empty regardless of its type.
-        if (!empty($value)) {
+        if (! empty($value)) {
             return false;
         }
 
@@ -158,7 +158,7 @@ class ObjectSerializer
                 // For boolean values, '' is considered empty
             case 'bool':
             case 'boolean':
-                return !in_array($value, [false, 0], true);
+                return ! in_array($value, [false, 0], true);
 
                 // For string values, '' is considered empty.
             case 'string':
@@ -213,7 +213,7 @@ class ObjectSerializer
         // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
         // need to flatten array first
         $flattenArray = function ($arr, $name, &$result = []) use (&$flattenArray, $style, $explode) {
-            if (!is_array($arr)) {
+            if (! is_array($arr)) {
                 return $arr;
             }
 
@@ -223,7 +223,7 @@ class ObjectSerializer
                 if (is_array($v)) {
                     $flattenArray($v, $prop, $result);
                 } else {
-                    if ($style !== 'deepObject' && !$explode) {
+                    if ($style !== 'deepObject' && ! $explode) {
                         // push key itself
                         $result[] = $prop;
                     }
@@ -361,7 +361,7 @@ class ObjectSerializer
         if (strcasecmp(substr($class, -2), '[]') === 0) {
             $data = is_string($data) ? json_decode($data) : $data;
 
-            if (!is_array($data)) {
+            if (! is_array($data)) {
                 throw new \InvalidArgumentException("Invalid array '$class'");
             }
 
@@ -407,7 +407,7 @@ class ObjectSerializer
             // what is meant. The invalid empty string is probably to
             // be interpreted as a missing field/value. Let's handle
             // this graceful.
-            if (!empty($data)) {
+            if (! empty($data)) {
                 try {
                     return new \DateTime($data);
                 } catch (\Exception $exception) {
@@ -454,7 +454,7 @@ class ObjectSerializer
         }
 
         if (method_exists($class, 'getAllowableEnumValues')) {
-            if (!in_array($data, $class::getAllowableEnumValues(), true)) {
+            if (! in_array($data, $class::getAllowableEnumValues(), true)) {
                 $imploded = implode("', '", $class::getAllowableEnumValues());
                 throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
@@ -469,7 +469,7 @@ class ObjectSerializer
 
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;
-            if (!empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {
+            if (! empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {
                 $subclass = '\OpenAPI\Client\Model\\'.$data->{$discriminator};
                 if (is_subclass_of($subclass, $class)) {
                     $class = $subclass;
@@ -481,11 +481,11 @@ class ObjectSerializer
             foreach ($instance::openAPITypes() as $property => $type) {
                 $propertySetter = $instance::setters()[$property];
 
-                if (!isset($propertySetter)) {
+                if (! isset($propertySetter)) {
                     continue;
                 }
 
-                if (!isset($data->{$instance::attributeMap()[$property]})) {
+                if (! isset($data->{$instance::attributeMap()[$property]})) {
                     if ($instance::isNullable($property)) {
                         $instance->$propertySetter(null);
                     }
@@ -520,7 +520,7 @@ class ObjectSerializer
      */
     public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
     {
-        if (!$params) {
+        if (! $params) {
             return '';
         }
 
@@ -547,7 +547,7 @@ class ObjectSerializer
         $qs = '';
         foreach ($params as $k => $v) {
             $k = $encoder((string) $k);
-            if (!is_array($v)) {
+            if (! is_array($v)) {
                 $qs .= $k;
                 $v = is_bool($v) ? $castBool($v) : $v;
                 if ($v !== null) {

--- a/src/FraudProtection.php
+++ b/src/FraudProtection.php
@@ -104,7 +104,6 @@ class FraudProtection
      *                         - form_data / formData (array)
      *                         - opportify_token / opportifyToken (string)
      *                         - opportify_form_uuid / opportifyFormUUID (string)
-     *                         - enable_ai / enableAi (bool, default: true)
      *
      * @throws \Exception
      */
@@ -233,9 +232,6 @@ class FraudProtection
                 break;
             }
         }
-
-        // enable_ai: default true
-        $normalized['enable_ai'] = $this->resolveBoolean($params, ['enable_ai', 'enableAi'], true);
 
         if (!isset($normalized['email']) && !isset($normalized['user_ip'])) {
             throw new \InvalidArgumentException('At least one of email or user_ip is required.');

--- a/tests/FraudProtectionTest.php
+++ b/tests/FraudProtectionTest.php
@@ -87,7 +87,6 @@ class FraudProtectionTest extends TestCase
         $response = $fp->analyze([
             'email' => 'test@example.com',
             'user_ip' => '1.2.3.4',
-            'enable_ai' => true,
         ]);
 
         $this->assertIsObject($response);
@@ -142,7 +141,6 @@ class FraudProtectionTest extends TestCase
             'user_ip' => '10.0.0.1',
             'first_name' => 'Jane',
             'last_name' => 'Doe',
-            'enable_ai' => false,
         ];
 
         $expected = [
@@ -150,7 +148,6 @@ class FraudProtectionTest extends TestCase
             'user_ip' => '10.0.0.1',
             'first_name' => 'Jane',
             'last_name' => 'Doe',
-            'enable_ai' => false,
         ];
 
         $reflection = new \ReflectionClass($fp);
@@ -169,7 +166,6 @@ class FraudProtectionTest extends TestCase
             'userIp' => '10.0.0.1',
             'firstName' => 'Jane',
             'lastName' => 'Doe',
-            'enableAi' => true,
         ];
 
         $reflection = new \ReflectionClass($fp);
@@ -180,7 +176,7 @@ class FraudProtectionTest extends TestCase
         $this->assertEquals('10.0.0.1', $normalized['user_ip']);
         $this->assertEquals('Jane', $normalized['first_name']);
         $this->assertEquals('Doe', $normalized['last_name']);
-        $this->assertTrue($normalized['enable_ai']);
+        $this->assertArrayNotHasKey('enable_ai', $normalized);
     }
 
     public function test_normalize_request_form_data_array()
@@ -214,7 +210,7 @@ class FraudProtectionTest extends TestCase
         $method->invokeArgs($fp, [['form_data' => 'not-an-array']]);
     }
 
-    public function test_enable_ai_defaults_to_true()
+    public function test_normalize_request_enable_ai_is_not_a_supported_field()
     {
         $fp = new FraudProtection('fake_api_key');
 
@@ -223,7 +219,7 @@ class FraudProtectionTest extends TestCase
         $method->setAccessible(true);
         $normalized = $method->invokeArgs($fp, [['email' => 'user@example.com']]);
 
-        $this->assertTrue($normalized['enable_ai']);
+        $this->assertArrayNotHasKey('enable_ai', $normalized);
     }
 
     public function test_normalize_request_missing_email_and_user_ip_throws()


### PR DESCRIPTION
## What does this PR do?

Regenerates the PHP client library from the latest API specifications and updates the `FraudProtection` wrapper to match schema changes in the fraud intelligence API.

## Why is this needed?

The API specifications were updated. Key changes in the fraud intelligence API:
- `enable_ai` field removed from the analyze request
- `meta` field removed from the analyze response
- `AnalyzeFraud200ResponseSourcesEmail` restructured — `format` sub-object replaced by flat fields (`email_address`, `email_provider`, `email_type`, etc.)
- `AnalyzeFraud200ResponseSourcesContent.content` is now nullable

## How was it implemented?

- Regenerated `lib/v1/` (insights) and `lib/fraud-intel/` client libraries — 26 files updated
- Updated `FraudProtection::normalizeRequest()` to remove `enable_ai` handling
- Updated `FraudProtectionTest` to reflect the removed field

## Are there any breaking changes?

Yes. If you were passing `enable_ai` to `FraudProtection::analyze()`, that field is now ignored by the API. Remove it from your request.

The `meta` key is no longer present in the analyze response.

## Testing

```bash
composer install
php vendor/bin/phpunit tests/ --no-configuration
```

All 102 tests pass.